### PR TITLE
Added Paris Metro Sprague-Thomson (4 variants) to default config.

### DIFF
--- a/VehicleConverter/Config/Trains.cs
+++ b/VehicleConverter/Config/Trains.cs
@@ -58,7 +58,11 @@ namespace VehicleConverter.Config
                     new TrainItem(730504141, "C14 - Stockholm metro train - with colorable stripe"),
                     new TrainItem(722264461, "S1 Metro"),
                     new TrainItem(805595183, "Stadler Glasgow EMU [4 Car]"),
-                    new TrainItem(805595573, "Stadler Glasgow EMU [6 Car]"), 
+                    new TrainItem(805595573, "Stadler Glasgow EMU [6 Car]"),
+                    new TrainItem(815155700, "Paris Metro Sprague-Thomson (2 car)"), 
+                    new TrainItem(815157636, "Paris Metro Sprague-Thomson (3 car)"), 
+                    new TrainItem(815158936, "Paris Metro Sprague-Thomson (4 car)"), 
+                    new TrainItem(815159453, "Paris Metro Sprague-Thomson (5 car)"),                     
                 }
             },
             {
@@ -84,7 +88,6 @@ namespace VehicleConverter.Config
                     //London overground
                     new TrainItem(559175122, "British Rail Class 378 (Line Colour)"),
                     new TrainItem(527925460, "British Rail Class 378"),  
-
                 }
             },
             {


### PR DESCRIPTION
Hi Penguin, I was already on my way to create a pull-request including the additional entries for the default config, when I realized an existing config wouldn't get updated with new default entries.
Did/would you change that? After all, I could understand if not, since updating user edited files can be annoying. 

I thought a mini-mod like this would be the best solution (least pain in the ass implementaion-wise and maximum control and no config editing for the subscribers) to add additional conversions afterwards. I do a check if a vehicle was already converted, so it would be ok if your mod already did the conversion. Did you notice any problems/incompatibilities?

Also, I didn't set the default metro motion parameters on conversion, mainly because sound effects just don't sound well with them. Extra Vehicle Effects mod offers an option to set optimal values for accelration and braking coefficent after the effects have been initialized. 
So far, this also worked for converted trains (probably just luck with initilization order), but it would be nice, if you could emit an event after conversion is completed.

If you would like it, I could create a repository for the conversion mini mod, but actually there is nothing interesting. I hope to create a repo for Extra Vehicle Effects today, still some code cleanup to do... ;-)